### PR TITLE
Integrate Packaide availability message

### DIFF
--- a/frontend-erp/src/modules/Producao/components/Nesting.jsx
+++ b/frontend-erp/src/modules/Producao/components/Nesting.jsx
@@ -74,6 +74,16 @@ const Nesting = () => {
   const [mostrarSobras, setMostrarSobras] = useState(false);
 
   useEffect(() => {
+    fetchComAuth('/packaide-status')
+      .then((d) => {
+        if (d && d.packaide) {
+          alert('Packaide iniciado');
+        }
+      })
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
     const cfg = JSON.parse(localStorage.getItem("nestingConfig") || "{}");
     if (cfg.pastaLote) setPastaLote(cfg.pastaLote);
     if (cfg.larguraChapa) setLarguraChapa(cfg.larguraChapa);

--- a/producao/backend/NESTING.md
+++ b/producao/backend/NESTING.md
@@ -30,11 +30,12 @@ A comunicação acontece via requisições HTTP (fetch) do frontend para a API.
    - `/executar-nesting` – chama `gerar_nesting_preview` e retorna a prévia com a lista de layers encontrados.
    - `/nesting-preview` – repete a geração da prévia para visualização.
    - `/executar-nesting-final` – executa `gerar_nesting`, grava o resultado em `Lote_X/nesting/` e registra na tabela `nestings`.
+   - `/packaide-status` – indica se o motor Packaide está disponível no servidor.
 
 4. **Função `gerar_nesting`** (`nesting.py`)
    - Lê o arquivo `.dxt` do lote para obter as peças.
    - Consulta a tabela `chapas` para saber tamanho e possibilidade de rotação de cada material.
-   - Executa o empacotamento utilizando o motor configurado. Por padrão é empregado o `Packaide`, com suporte a formas irregulares e rotação. Quando o pacote não está disponível o sistema recorre ao algoritmo baseado em `rectpack`.
+   - Executa o empacotamento utilizando o motor configurado. Por padrão é empregado o `Packaide`, com suporte a formas irregulares e rotação. Caso o pacote não esteja instalado via `pip`, o backend tenta carregá-lo a partir da pasta `externals/Packaide`. Quando a biblioteca não está presente o sistema recorre ao algoritmo baseado em `rectpack`.
    - Para cada chapa resultante, chama funções auxiliares que geram os arquivos de saída (gcodes, cyc, xml, imagens e etiquetas).
    - Os resultados são gravados em `Lote_X/nesting/` e o caminho é retornado ao frontend.
 

--- a/producao/backend/src/api.py
+++ b/producao/backend/src/api.py
@@ -46,6 +46,7 @@ from nesting import (
 )
 import ezdxf
 from typing import Union, Dict, List
+from packaide_wrapper import is_available as packaide_available
 
 
 def _age_seconds(value) -> float | None:
@@ -404,6 +405,12 @@ async def gerar_lote_final(request: Request):
         time.sleep(2)
 
     return {"status": "ok", "mensagem": "Arquivos gerados com sucesso."}
+
+
+@app.get("/packaide-status")
+async def packaide_status():
+    """Retorna ``True`` se o motor Packaide está disponível."""
+    return {"packaide": packaide_available()}
 
 
 @app.get("/carregar-lote-final")

--- a/producao/backend/src/packaide_wrapper.py
+++ b/producao/backend/src/packaide_wrapper.py
@@ -9,17 +9,37 @@ back to a very naive rectangle packing algorithm implemented with
 The wrapper exposes a single function ``pack`` which receives a list of
 pieces (dictionaries with ``Length`` and ``Width``) and returns a list of
 bins with placement information compatible with ``rectpack`` objects.
+
+When ``packaide`` is not installed as a Python package the module attempts
+to load it from ``externals/Packaide`` under the repository root.  If the
+library is still missing a simplified heuristic algorithm is used instead.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Iterable, List, Dict, Tuple
+from pathlib import Path
+import importlib
+import sys
 
 try:  # pragma: no cover - optional dependency
     import packaide  # type: ignore
 except Exception:  # pragma: no cover - import failure handled at runtime
     packaide = None
+    _ext_dir = Path(__file__).resolve().parents[3] / "externals" / "Packaide"
+    if _ext_dir.exists():
+        sys.path.append(str(_ext_dir))
+        try:
+            packaide = importlib.import_module("packaide")  # type: ignore
+        except Exception:
+            packaide = None
+
+PACKAIDE_AVAILABLE = packaide is not None
+
+def is_available() -> bool:
+    """Return ``True`` when the Packaide engine could be imported."""
+    return packaide is not None
 
 from shapely.geometry import box
 from shapely import affinity


### PR DESCRIPTION
## Summary
- add utility to check if Packaide module was imported
- expose `/packaide-status` endpoint in the backend
- display an alert when Packaide is available
- document the new endpoint in `NESTING.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e6146fe04832dae9cb8b448ceafb5