### PR TITLE
Fix plate rotation offsets

### DIFF
--- a/producao/backend/src/nesting.py
+++ b/producao/backend/src/nesting.py
@@ -197,18 +197,20 @@ def _is_operacao(cfg: Dict) -> bool:
 
 
 def _rotate_rect_cw(x: float, y: float, w: float, h: float, largura: float) -> tuple:
-    """Rotate rectangle 270 degrees clockwise so that the rotated plate starts
-    at the lower-left origin."""
-    return y, x, h, w
+    """Rotate rectangle 90 degrees clockwise within a plate of width ``largura``.
+
+    Coordinates in this module consider the origin at the lower-left of the
+    plate. After rotation the origin also remains at the lower-left, therefore
+    the ``y`` coordinate needs to be mirrored using the plate width.
+    """
+    return y, largura - x - w, h, w
 
 
 def _rotate_poly_cw(poly: Polygon, largura: float) -> Polygon:
-    """Rotate polygon 270 degrees clockwise keeping coordinates positive with
-    origin at the lower-left."""
+    """Rotate polygon 90 degrees clockwise keeping coordinates positive."""
     g = affinity.rotate(poly, -90, origin=(0, 0))
-    g = affinity.scale(g, yfact=-1, origin=(0, 0))
-    minx, miny, _, _ = g.bounds
-    return affinity.translate(g, xoff=-minx, yoff=-miny)
+    g = affinity.translate(g, yoff=largura)
+    return g
 
 
 def _rotate_plate_cw(chapa: Dict) -> Dict:
@@ -225,7 +227,7 @@ def _rotate_plate_cw(chapa: Dict) -> Dict:
         nx, ny, nw, nh = _rotate_rect_cw(x, y, w, h, largura)
         op["x"], op["y"], op["largura"], op["altura"] = nx, ny, nw, nh
         if op.get("coords"):
-            op["coords"] = [[cy, cx] for cx, cy in op["coords"]]
+            op["coords"] = [[cy, largura - cx] for cx, cy in op["coords"]]
         if isinstance(op.get("polygon"), (Polygon, MultiPolygon)):
             op["polygon"] = _rotate_poly_cw(op["polygon"], largura)
     chapa["largura"], chapa["altura"] = altura, largura


### PR DESCRIPTION
## Summary
- correct coordinate math for rotated plates in backend nesting logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687edd755ff8832db254bf2a79a76e5f