### PR TITLE
Implement template file upload

### DIFF
--- a/DOCUMENTACAO_COMPLETA.md
+++ b/DOCUMENTACAO_COMPLETA.md
@@ -118,6 +118,10 @@ Relacionadas às rotas de produção descritas na seção anterior.
 - **AtendimentoTarefa** – tabela `atendimento_tarefas` (tarefas por atendimento).
 - **CondicaoPagamento** – tabela `condicoes_pagamento` (parcelas e juros).
 - **Template** – tabela `templates` (tipo, título, campos).
+- Cada registro pode opcionalmente ter `arquivo_key` apontando para um
+  documento `.docx` ou `.pdf` salvo no bucket S3. Na geração de arquivos,
+  tokens no formato `[campo]` dentro do documento são substituídos pelos
+  valores definidos em `autoCampo` nos templates visuais.
 - **ProjetoItem** – tabela `projeto_itens` (itens de projeto dentro de tarefas).
 - **GabsterProjetoItem** – tabela `gabster_projeto_itens` para itens importados da API.
   Os registros são gravados ao atualizar uma tarefa de projeto com `programa` igual a `Gabster`.

--- a/comercial-backend/main.py
+++ b/comercial-backend/main.py
@@ -9,6 +9,7 @@ from storage import (
     delete_file,
     get_public_url,
     object_exists,
+    download_stream,
 )
 from datetime import datetime
 import logging
@@ -674,11 +675,77 @@ async def criar_template(request: Request):
     with get_db_connection() as conn:
         new_id = insert_with_id(
             conn,
-            "INSERT INTO templates (tipo, titulo, campos_json) VALUES (%s, %s, %s)",
-            (data.get("tipo"), data.get("titulo"), campos),
+            "INSERT INTO templates (tipo, titulo, campos_json, arquivo_key) VALUES (%s, %s, %s, %s)",
+            (data.get("tipo"), data.get("titulo"), campos, data.get("arquivo_key")),
         )
         conn.commit()
     return {"id": new_id}
+
+
+@app.post("/templates/upload")
+async def upload_template(tipo: str, titulo: str, file: UploadFile = File(...)):
+    """Importar arquivo DOCX ou PDF para um novo template."""
+    ext = os.path.splitext(file.filename or "")[1].lower()
+    if ext not in {".docx", ".pdf"}:
+        raise HTTPException(status_code=400, detail="Apenas .docx ou .pdf")
+
+    tmp = tempfile.NamedTemporaryFile(delete=False, suffix=ext)
+    try:
+        contents = await file.read()
+        tmp.write(contents)
+        tmp.close()
+        key = f"templates/{tipo}/{titulo}_{int(datetime.utcnow().timestamp())}{ext}"
+        upload_file(tmp.name, key)
+    finally:
+        os.remove(tmp.name)
+
+    with get_db_connection() as conn:
+        new_id = insert_with_id(
+            conn,
+            "INSERT INTO templates (tipo, titulo, campos_json, arquivo_key) VALUES (%s, %s, %s, %s)",
+            (tipo, titulo, json.dumps([]), key),
+        )
+        conn.commit()
+
+    return {"id": new_id, "arquivo_key": key, "arquivo_url": get_public_url(key)}
+
+
+@app.post("/templates/{template_id}/upload")
+async def upload_template_file(template_id: int, file: UploadFile = File(...)):
+    """Anexar ou substituir o arquivo de um template existente."""
+    ext = os.path.splitext(file.filename or "")[1].lower()
+    if ext not in {".docx", ".pdf"}:
+        raise HTTPException(status_code=400, detail="Apenas .docx ou .pdf")
+
+    with get_db_connection() as conn:
+        row = (
+            conn.exec_driver_sql(
+                "SELECT tipo, titulo FROM templates WHERE id=%s", (template_id,),
+            )
+            .mappings()
+            .fetchone()
+        )
+    if not row:
+        return JSONResponse({"detail": "Template não encontrado"}, status_code=404)
+
+    key = f"templates/{row['tipo']}/{row['titulo']}_{int(datetime.utcnow().timestamp())}{ext}"
+
+    tmp = tempfile.NamedTemporaryFile(delete=False, suffix=ext)
+    try:
+        tmp.write(await file.read())
+        tmp.close()
+        upload_file(tmp.name, key)
+    finally:
+        os.remove(tmp.name)
+
+    with get_db_connection() as conn:
+        conn.exec_driver_sql(
+            "UPDATE templates SET arquivo_key=%s WHERE id=%s",
+            (key, template_id),
+        )
+        conn.commit()
+
+    return {"arquivo_key": key, "arquivo_url": get_public_url(key)}
 
 
 @app.get("/templates/{template_id}")
@@ -699,7 +766,68 @@ async def obter_template(template_id: int):
                 item["campos"] = json.loads(item["campos_json"])
             except Exception:
                 item["campos"] = []
+        if item.get("arquivo_key"):
+            item["arquivo_url"] = get_public_url(item["arquivo_key"])
         return {"template": item}
+
+
+@app.post("/templates/{template_id}/gerar")
+async def gerar_documento(template_id: int, request: Request):
+    """Gerar documento substituindo tokens [campo]"""
+    data = await request.json()
+    valores: dict = data.get("valores", {})
+
+    with get_db_connection() as conn:
+        row = (
+            conn.exec_driver_sql(
+                "SELECT * FROM templates WHERE id=%s", (template_id,)
+            )
+            .mappings()
+            .fetchone()
+        )
+    if not row:
+        return JSONResponse({"detail": "Template não encontrado"}, status_code=404)
+
+    tpl = dict(row)
+    key = tpl.get("arquivo_key")
+    if not key:
+        raise HTTPException(status_code=400, detail="Template sem arquivo")
+
+    stream = download_stream(key, key)
+    ext = os.path.splitext(key)[1].lower()
+    from io import BytesIO
+
+    if ext == ".docx":
+        from docx import Document
+
+        doc = Document(stream)
+        for p in doc.paragraphs:
+            for placeholder, value in valores.items():
+                token = f"[{placeholder}]"
+                if token in p.text:
+                    for run in p.runs:
+                        if token in run.text:
+                            run.text = run.text.replace(token, str(value))
+
+        output = BytesIO()
+        doc.save(output)
+        output.seek(0)
+        media = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        return StreamingResponse(output, media_type=media)
+
+    elif ext == ".pdf":
+        content = stream.read()
+        try:
+            txt = content.decode("latin-1")
+            for placeholder, value in valores.items():
+                txt = txt.replace(f"[{placeholder}]", str(value))
+            output = BytesIO(txt.encode("latin-1"))
+            return StreamingResponse(output, media_type="application/pdf")
+        except Exception:
+            raise HTTPException(status_code=400, detail="Falha ao gerar PDF")
+
+    else:
+        raise HTTPException(status_code=400, detail="Formato não suportado")
 
 
 @app.put("/templates/{template_id}")
@@ -708,8 +836,8 @@ async def atualizar_template(template_id: int, request: Request):
     campos = json.dumps(data.get("campos", []))
     with get_db_connection() as conn:
         conn.exec_driver_sql(
-            """UPDATE templates SET titulo=%s, tipo=%s, campos_json=%s WHERE id=%s""",
-            (data.get("titulo"), data.get("tipo"), campos, template_id),
+            """UPDATE templates SET titulo=%s, tipo=%s, campos_json=%s, arquivo_key=%s WHERE id=%s""",
+            (data.get("titulo"), data.get("tipo"), campos, data.get("arquivo_key"), template_id),
         )
         conn.commit()
     return {"ok": True}

--- a/comercial-backend/models.py
+++ b/comercial-backend/models.py
@@ -59,6 +59,7 @@ class Template(Base):
     tipo = Column(String)
     titulo = Column(String)
     campos_json = Column(String)
+    arquivo_key = Column(String)
 
 
 class ProjetoItem(Base):

--- a/frontend-erp/src/modules/Cadastros/templates/ListaTemplates.jsx
+++ b/frontend-erp/src/modules/Cadastros/templates/ListaTemplates.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { Button } from '../../Producao/components/ui/button';
 import { fetchComAuth } from '../../../utils/fetchComAuth';
@@ -25,6 +25,7 @@ const nomeTipo = tipo => {
 function ListaTemplates() {
   const { tipo } = useParams();
   const [lista, setLista] = useState([]);
+  const fileRef = useRef();
 
   const carregar = async () => {
     try {
@@ -43,11 +44,29 @@ function ListaTemplates() {
     carregar();
   };
 
+  const selecionarArquivo = () => {
+    fileRef.current?.click();
+  };
+
+  const enviarArquivo = async e => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const form = new FormData();
+    form.append('file', file);
+    form.append('tipo', tipo);
+    form.append('titulo', file.name);
+    await fetchComAuth('/comercial/templates/upload', { method: 'POST', body: form });
+    e.target.value = '';
+    carregar();
+  };
+
   return (
     <div className="space-y-2">
-      <div className="flex justify-between items-center">
+      <div className="flex justify-between items-center gap-2">
         <h3 className="text-lg font-semibold">Templates de {nomeTipo(tipo)}</h3>
         <Button asChild><Link to="novo">Novo Template</Link></Button>
+        <Button variant="secondary" onClick={selecionarArquivo}>Importar arquivo</Button>
+        <input ref={fileRef} type="file" accept=".docx,.pdf" className="hidden" onChange={enviarArquivo} />
       </div>
       <ul className="space-y-1">
         {lista.map(t => (


### PR DESCRIPTION
## Summary
- support `arquivo_key` in Template model and docs
- allow creating templates from file upload
- generate docs by replacing `[campo]` tokens
- enable file upload from frontend templates list
- let builders update an existing template file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687edc55b7f8832db6b07d3094a30689