### PR TITLE
Fix Gabster project data visibility and negotiation

### DIFF
--- a/frontend-erp/src/modules/Comercial/pages/AtendimentoDetalhes.jsx
+++ b/frontend-erp/src/modules/Comercial/pages/AtendimentoDetalhes.jsx
@@ -181,7 +181,7 @@ function TarefaItem({ tarefa, atendimentoId, onChange, projetos, bloqueada }) {
             [amb]: { codigo, ...dadosAmb },
           },
         };
-        setDados(novos);
+        setDados(() => novos);
         await salvarProjeto(novos);
         alert('Importação realizada com sucesso');
       } catch (err) {
@@ -210,7 +210,7 @@ function TarefaItem({ tarefa, atendimentoId, onChange, projetos, bloqueada }) {
             [amb]: { arquivo: file.name, ...dadosAmb },
           },
         };
-        setDados(novos);
+        setDados(() => novos);
         await salvarProjeto(novos);
         alert('Importação realizada com sucesso');
       } catch (err) {

--- a/frontend-erp/src/modules/Comercial/pages/ListagemProjeto.jsx
+++ b/frontend-erp/src/modules/Comercial/pages/ListagemProjeto.jsx
@@ -24,9 +24,8 @@ export default function ListagemProjeto() {
       const orc = t.tarefas.find(tt => String(tt.id) === String(tarefaId));
       if (!orc) return;
       let dados = {};
-
       try {
-        dados = orc.dados ? JSON.parse(orc.dados) : {};
+        dados = typeof orc.dados === 'string' ? JSON.parse(orc.dados) : orc.dados || {};
       } catch {
         // ignore parse errors
       }

--- a/frontend-erp/src/modules/Comercial/pages/Negociacao.jsx
+++ b/frontend-erp/src/modules/Comercial/pages/Negociacao.jsx
@@ -6,6 +6,7 @@ import { Button } from '../../Producao/components/ui/button';
 import { fetchComAuth } from '../../../utils/fetchComAuth';
 
 const currency = v => Number(v || 0).toLocaleString('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+const normalize = str => (str || '').normalize('NFD').replace(/\p{Diacritic}/gu, '').trim().toLowerCase();
 
 function Negociacao() {
   const { id, tarefaId } = useParams();
@@ -46,10 +47,11 @@ function Negociacao() {
       try { dadosProj = proj && proj.dados ? JSON.parse(proj.dados) : {}; } catch (e) { /* ignore */ }
       try { dadosNeg = orcAtual && orcAtual.dados ? JSON.parse(orcAtual.dados) : {}; } catch (e) { /* ignore */ }
       const projs = (at.atendimento.projetos || '').split(',').map(p => p.trim()).filter(Boolean);
-      const listaAmb = projs.map(a => ({
-        nome: a,
-        valor: dadosProj.projetos?.[a]?.total || dadosProj.projetos?.[a]?.valor || 0
-      }));
+      const getValorAmb = nome => {
+        const chave = Object.keys(dadosProj.projetos || {}).find(k => normalize(k) === normalize(nome));
+        return dadosProj.projetos?.[chave || nome]?.total || dadosProj.projetos?.[chave || nome]?.valor || 0;
+      };
+      const listaAmb = projs.map(a => ({ nome: a, valor: getValorAmb(a) }));
       setAmbientes(listaAmb);
       setSelecionados(listaAmb.reduce((acc, a) => ({ ...acc, [a.nome]: true }), {}));
       if (dadosNeg.pontuacao) setPontuacao(String(dadosNeg.pontuacao));


### PR DESCRIPTION
## Summary
- ensure new Gabster data overwrites state correctly
- parse task data robustly in project list
- normalise ambiente names when loading negotiation values

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687fbc4143e8832daa6215de57ef55bc