### PR TITLE
Fix polygon coordinate unpacking in nesting preview

### DIFF
--- a/producao/backend/src/nesting.py
+++ b/producao/backend/src/nesting.py
@@ -749,14 +749,20 @@ def _gerar_imagens_chapas(
                 geoms = [poly] if isinstance(poly, Polygon) else list(poly.geoms)
                 for geom in geoms:
                     coords = [
-                        (int(x * escala), altura_img - int(y * escala))
-                        for x, y in geom.exterior.coords
+                        (
+                            int(c[0] * escala),
+                            altura_img - int(c[1] * escala),
+                        )
+                        for c in geom.exterior.coords
                     ]
                     draw.polygon(coords, outline="black")
                     for interior in geom.interiors:
                         coords = [
-                            (int(x * escala), altura_img - int(y * escala))
-                            for x, y in interior.coords
+                            (
+                                int(c[0] * escala),
+                                altura_img - int(c[1] * escala),
+                            )
+                            for c in interior.coords
                         ]
                         draw.polygon(coords, outline="black")
             else:


### PR DESCRIPTION
## Summary
- handle polygons that may contain z-values when generating preview images

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688019057018832d8815a3cba6cee6e8