### PR TITLE
Implement Gabster project listing

### DIFF
--- a/comercial-backend/gabster_api.py
+++ b/comercial-backend/gabster_api.py
@@ -1,5 +1,7 @@
 import os
-from typing import Any, Optional
+from typing import Any, Optional, List
+
+from pydantic import BaseModel
 
 from dotenv import load_dotenv
 
@@ -8,6 +10,20 @@ load_dotenv()
 import requests
 
 BASE_URL = "https://api.gabster.com.br/integracao/api/v2/"
+
+
+class Projeto(BaseModel):
+    """Representation of the Projeto object returned by the Gabster API."""
+
+    id: int
+    nome: Optional[str] = None
+    cd_cliente: Optional[int] = None
+    nome_arquivo_skp: Optional[str] = None
+    identificador_arquivo_skp: Optional[str] = None
+    descricao: Optional[str] = None
+    observacao: Optional[str] = None
+    ambiente: Optional[str] = None
+    projeto_ref: Optional[int] = None
 
 
 def _auth_header(user: Optional[str] = None, api_key: Optional[str] = None) -> dict:
@@ -51,4 +67,31 @@ def list_orcamento_cliente_item(
     response = requests.get(url, headers=headers, timeout=15)
     response.raise_for_status()
     return response.json()
+
+
+def list_projetos(
+    offset: int = 0,
+    limit: int = 20,
+    *,
+    user: Optional[str] = None,
+    api_key: Optional[str] = None,
+) -> List[Projeto]:
+    """Return a list of ``Projeto`` objects from the Gabster API."""
+    url = f"{BASE_URL}projeto/?offset={offset}&limit={limit}&format=json"
+    headers = _auth_header(user, api_key)
+    response = requests.get(url, headers=headers, timeout=15)
+    response.raise_for_status()
+    data = response.json()
+    projetos = []
+    if isinstance(data, dict):
+        items = data.get("results") or data.get("items") or data.get("data") or []
+    else:
+        items = data
+    for item in items:
+        try:
+            projetos.append(Projeto(**item))
+        except Exception:
+            # ignore invalid items
+            continue
+    return projetos
 

--- a/tests/comercial/test_gabster_api.py
+++ b/tests/comercial/test_gabster_api.py
@@ -1,0 +1,45 @@
+import sys
+import importlib
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+MOD_DIR = ROOT_DIR / "comercial-backend"
+
+
+def load_module():
+    sys.path.insert(0, str(MOD_DIR))
+    try:
+        return importlib.import_module("gabster_api")
+    finally:
+        sys.path.pop(0)
+
+
+def test_list_projetos(monkeypatch):
+    gabster_api = load_module()
+
+    class MockResponse:
+        def __init__(self, data, status=200):
+            self._data = data
+            self.status_code = status
+            self.text = str(data)
+
+        def json(self):
+            return self._data
+
+        def raise_for_status(self):
+            if self.status_code >= 400:
+                raise gabster_api.requests.HTTPError("error")
+
+    calls = []
+
+    def fake_get(url, headers=None, timeout=15):
+        calls.append(url)
+        return MockResponse([{"id": 1, "nome": "Proj", "cd_cliente": 2}])
+
+    monkeypatch.setattr(gabster_api.requests, "get", fake_get)
+    projetos = gabster_api.list_projetos(offset=5, limit=10, user="u", api_key="k")
+    assert calls
+    assert "offset=5" in calls[0]
+    assert len(projetos) == 1
+    assert projetos[0].id == 1
+    assert projetos[0].nome == "Proj"


### PR DESCRIPTION
## Summary
- model Gabster `Projeto` with Pydantic
- add `list_projetos` helper to consume `/projeto/` API
- test project listing behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880f68546b0832d83846c01c8e844f2