### PR TITLE
Fix syntax issue in estoque loader

### DIFF
--- a/producao/backend/src/nesting.py
+++ b/producao/backend/src/nesting.py
@@ -1592,7 +1592,7 @@ def _carregar_estoque(materiais: List[str]) -> Dict[str, List[Dict]]:
             )
             for r in rows:
 
-                desc = (r.get(\"descricao\") or \"\").lower()
+                desc = (r.get("descricao") or "").lower()
 
                 for m in materiais:
                     if m.lower() in desc:


### PR DESCRIPTION
## Summary
- fix escaped quotes in `_carregar_estoque`
- update tests dependencies to run unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688138bb23a4832d9389865c23b30dce