### PR TITLE
Handle dict payload for Projeto 3D data

### DIFF
--- a/comercial-backend/main.py
+++ b/comercial-backend/main.py
@@ -827,12 +827,17 @@ async def atualizar_tarefa(atendimento_id: int, tarefa_id: int, request: Request
         campos.append("data_execucao=%s")
         valores.append(datetime.utcnow().isoformat() if concl else None)
     if "dados" in data:
+        raw_dados = data["dados"]
+        if isinstance(raw_dados, (dict, list)):
+            dados_json = raw_dados
+            raw_dados = json.dumps(raw_dados)
+        else:
+            try:
+                dados_json = json.loads(raw_dados)
+            except Exception:
+                dados_json = {}
         campos.append("dados=%s")
-        valores.append(data["dados"])
-        try:
-            dados_json = json.loads(data["dados"])
-        except Exception:
-            dados_json = {}
+        valores.append(raw_dados)
     if not campos:
         return {"detail": "Nada para atualizar"}
     valores.extend([atendimento_id, tarefa_id])


### PR DESCRIPTION
## Summary
- allow Projeto 3D task updates to accept dictionaries or lists in `dados`
- cover saving and finalizing Projeto 3D tasks when payload is a dict

## Testing
- `pytest tests/comercial/test_projeto3d_persist.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689201f06e74832da92ae1fa84948063