### PR TITLE
Fix orçamento template logo and buttons

### DIFF
--- a/comercial-backend/main.py
+++ b/comercial-backend/main.py
@@ -599,7 +599,9 @@ async def negociacao_html(request: Request, atendimento_id: int, tarefa_id: int)
             "total": total_final,
             "validade": validade.strftime("%d/%m/%Y"),
             "info_text": info_text,
-            "logo_url": request.url_for("static", path="logo.png"),
+            "logo_url": request.url_for("static", path="LOGO-RADHA---NORMAL.png")
+            if os.path.exists(os.path.join(static_dir, "LOGO-RADHA---NORMAL.png"))
+            else None,
         },
     )
 

--- a/comercial-backend/templates/orcamento.html
+++ b/comercial-backend/templates/orcamento.html
@@ -6,20 +6,24 @@
   <title>{{ titulo }}</title>
   <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
   <script src="https://cdn.jsdelivr.net/npm/signature_pad@4.1.5/dist/signature_pad.umd.min.js"></script>
+  <style>
+    @media print {
+      .no-print {
+        display: none;
+      }
+    }
+  </style>
 </head>
 <body class="bg-gray-50 p-6">
   <div class="max-w-4xl mx-auto bg-white shadow rounded-lg overflow-hidden">
     <div class="p-6 bg-gray-100 border-b flex items-center justify-between">
       <div class="flex items-center space-x-4">
         {% if logo_url %}
-        <img src="{{ logo_url }}" alt="Logo" class="h-16" onerror="this.onerror=null;this.src='data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMjAiIGhlaWdodD0iNDAiPjxyZWN0IHdpZHRoPSIxMjAiIGhlaWdodD0iNDAiIGZpbGw9IiNkZGQiLz48dGV4dCB4PSI2MCIgeT0iMjUiIGZvbnQtc2l6ZT0iMTYiIHRleHQtYW5jaG9yPSJtaWRkbGUiIGZpbGw9IiM1NTUiPkxPR088L3RleHQ+PC9zdmc+';">
-        {% else %}
-        <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMjAiIGhlaWdodD0iNDAiPjxyZWN0IHdpZHRoPSIxMjAiIGhlaWdodD0iNDAiIGZpbGw9IiNkZGQiLz48dGV4dCB4PSI2MCIgeT0iMjUiIGZvbnQtc2l6ZT0iMTYiIHRleHQtYW5jaG9yPSJtaWRkbGUiIGZpbGw9IiM1NTUiPkxPR088L3RleHQ+PC9zdmc+" alt="Logo" class="h-16">
+        <img src="{{ logo_url }}" alt="Logo" class="h-16">
         {% endif %}
         <h1 class="text-2xl font-semibold text-gray-800">{{ titulo }}</h1>
       </div>
-      <div class="space-x-2">
-        <button onclick="downloadOrcamento()" class="px-4 py-2 bg-blue-600 text-white rounded">Baixar</button>
+      <div class="space-x-2 no-print">
         <button onclick="window.print()" class="px-4 py-2 bg-green-600 text-white rounded">Imprimir</button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Load RADHA logo from FastAPI static directory when available
- Show logo dynamically in orçamento template and hide controls on print

## Testing
- `pytest` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68922c814d9c832dbae7d0d5aed68d19