### PR TITLE
feat: move production batches to backend

### DIFF
--- a/producao/backend/src/lotes_producao.py
+++ b/producao/backend/src/lotes_producao.py
@@ -1,51 +1,81 @@
+"""Rotas e utilidades para persistência de lotes de produção."""
+
 from fastapi import APIRouter, HTTPException
-from sqlalchemy import func
 import json
 
-from .database import database, lotes_producao
+from database import get_db_connection, PLACEHOLDER, schema
+
 
 router = APIRouter()
 
+SCHEMA_PREFIX = f"{schema}." if schema else ""
+
+
+def salvar_lote_db(nome: str, pacotes: list) -> None:
+    """Cria ou atualiza um lote de produção no banco."""
+
+    pacotes_json = json.dumps(pacotes)
+    with get_db_connection() as conn:
+        conn.exec_driver_sql(
+            f"""
+            INSERT INTO {SCHEMA_PREFIX}lotes_producao (nome, pacotes_json)
+            VALUES ({PLACEHOLDER}, {PLACEHOLDER})
+            ON CONFLICT (nome)
+            DO UPDATE SET pacotes_json = {PLACEHOLDER}, atualizado_em = NOW()
+            """,
+            (nome, pacotes_json, pacotes_json),
+        )
+
+
 @router.post("/lotes-producao")
 async def salvar_lote_producao(lote: dict):
+    """Cria ou atualiza um lote com seus pacotes."""
+
     nome = lote.get("nome")
     pacotes = lote.get("pacotes", [])
     if not nome:
         raise HTTPException(status_code=400, detail="Nome do lote é obrigatório")
-    pacotes_json = json.dumps(pacotes)
-    query = (
-        lotes_producao.insert()
-        .values(nome=nome, pacotes_json=pacotes_json)
-        .on_conflict_do_update(
-            index_elements=[lotes_producao.c.nome],
-            set_={"pacotes_json": pacotes_json, "atualizado_em": func.now()},
-        )
-    )
-    await database.execute(query)
+
+    salvar_lote_db(nome, pacotes)
     return {"status": "ok"}
 
 
 @router.get("/lotes-producao")
 async def listar_lotes_producao():
-    query = lotes_producao.select()
-    rows = await database.fetch_all(query)
-    return [
-        {"nome": row["nome"], "atualizado_em": row["atualizado_em"]}
-        for row in rows
-    ]
+    """Lista todos os lotes cadastrados."""
+
+    with get_db_connection() as conn:
+        rows = conn.exec_driver_sql(
+            f"SELECT nome, atualizado_em FROM {SCHEMA_PREFIX}lotes_producao ORDER BY atualizado_em DESC"
+        ).mappings().all()
+    return [dict(row) for row in rows]
 
 
 @router.get("/lotes-producao/{nome}")
 async def obter_lote_producao(nome: str):
-    query = lotes_producao.select().where(lotes_producao.c.nome == nome)
-    row = await database.fetch_one(query)
+    """Obtém os dados de um lote pelo nome."""
+
+    with get_db_connection() as conn:
+        row = conn.exec_driver_sql(
+            f"SELECT pacotes_json FROM {SCHEMA_PREFIX}lotes_producao WHERE nome={PLACEHOLDER}",
+            (nome,),
+        ).mappings().first()
+
     if not row:
         raise HTTPException(status_code=404, detail="Lote não encontrado")
-    return json.loads(row["pacotes_json"] or "[]")
+
+    pacotes = json.loads(row["pacotes_json"] or "[]")
+    return {"nome": nome, "pacotes": pacotes}
 
 
 @router.delete("/lotes-producao/{nome}")
 async def excluir_lote_producao(nome: str):
-    query = lotes_producao.delete().where(lotes_producao.c.nome == nome)
-    await database.execute(query)
+    """Remove um lote pelo nome."""
+
+    with get_db_connection() as conn:
+        conn.exec_driver_sql(
+            f"DELETE FROM {SCHEMA_PREFIX}lotes_producao WHERE nome={PLACEHOLDER}",
+            (nome,),
+        )
     return {"status": "deleted"}
+


### PR DESCRIPTION
## Summary
- add database-backed endpoints to create, list, fetch and remove production lots
- persist lots during XML import
- load and save production batches through API instead of localStorage on the frontend

## Testing
- `pytest` *(fails: async def functions are not natively supported)*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68926a4aecc8832da374b47eff73b179