### PR TITLE
fix: import missing SQLAlchemy types

### DIFF
--- a/producao/backend/src/models.py
+++ b/producao/backend/src/models.py
@@ -1,5 +1,6 @@
 from sqlalchemy.orm import declarative_base
-from sqlalchemy import Column, Integer, String, Float
+from sqlalchemy import Column, Integer, String, Float, Text, TIMESTAMP
+from sqlalchemy.sql import func
 
 Base = declarative_base()
 
@@ -159,3 +160,4 @@ class LoteProducao(Base):
     usuario_id = Column(Integer, nullable=True)
     criado_em = Column(TIMESTAMP, server_default=func.now())
     atualizado_em = Column(TIMESTAMP, server_default=func.now(), onupdate=func.now())
+


### PR DESCRIPTION
## Summary
- import Text and TIMESTAMP and `func` for LoteProducao model

## Testing
- `pytest -q` (fails: httpx.ProxyError: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_689276b40bc8832d990c697432a0e0c7