### PR TITLE
fix: resolve relative import error

### DIFF
--- a/producao/backend/src/api.py
+++ b/producao/backend/src/api.py
@@ -27,7 +27,7 @@ from database import (
     PLACEHOLDER,
     schema,
 )
-from .lotes_producao import router as lotes_producao_router, salvar_lote_db
+from lotes_producao import router as lotes_producao_router, salvar_lote_db
 
 SCHEMA_PREFIX = f"{schema}." if schema else ""
 import tempfile


### PR DESCRIPTION
## Summary
- avoid relative import failure in production backend

## Testing
- `pytest` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68934e096b84832d8f14266bb9d0da6e