### PR TITLE
fix: send lote name when importing XML

### DIFF
--- a/frontend-erp/src/modules/Producao/AppProducao.jsx
+++ b/frontend-erp/src/modules/Producao/AppProducao.jsx
@@ -159,7 +159,7 @@ const LoteProducao = () => {
         <Button variant="outline" onClick={() => navigate("/producao")}>Voltar para Início da Produção</Button>
       </div>
 
-      <ImportarXML onImportarPacote={(p) => salvarPacotes([p])} />
+      <ImportarXML nomeLote={nome} onImportarPacote={(p) => salvarPacotes([p])} />
 
       <ul className="space-y-2 mt-4">
         {pacotes.map((p, i) => (

--- a/frontend-erp/src/modules/Producao/components/ImportarXML.jsx
+++ b/frontend-erp/src/modules/Producao/components/ImportarXML.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { fetchComAuth } from "../../../utils/fetchComAuth"; // Usando o utilitário corrigido
 
-const ImportarXML = ({ onImportarPacote }) => {
+const ImportarXML = ({ onImportarPacote, nomeLote }) => {
   const [carregando, setCarregando] = useState(false);
   const [arquivosSelecionados, setArquivosSelecionados] = useState(0);
 
@@ -14,6 +14,7 @@ const ImportarXML = ({ onImportarPacote }) => {
     if (!files.length) return;
 
     const formData = new FormData();
+    formData.append("nome", nomeLote);
     for (let i = 0; i < files.length; i++) {
       // O nome "files" deve corresponder ao que o backend espera
       formData.append("files", files[i]);


### PR DESCRIPTION
## Summary
- send selected lot name with XML upload requests to satisfy backend schema
- pass current lot name to ImportarXML component

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: no-unused-vars in Negociacao.jsx)
- `pytest` (fails: async def functions are not natively supported by pytests)


------
https://chatgpt.com/codex/tasks/task_e_68935508695c832d90c2773bd5baa7c1