### PR TITLE
fix: restore production lot import

### DIFF
--- a/producao/backend/src/api.py
+++ b/producao/backend/src/api.py
@@ -230,9 +230,13 @@ def coletar_chapas(pasta_lote: str) -> list[str]:
 
 @app.post("/importar-xml")
 async def importar_xml(
-    nome: str = Form(...), files: list[UploadFile] = File(...)
+    lote: str = Form(..., alias="nome"), files: list[UploadFile] = File(...)
 ):
-    """Importa arquivos de produção e persiste o lote informado."""
+    """Importa arquivos de produção e persiste o lote informado.
+
+    O parâmetro ``lote`` pode ser o ``id`` ou o ``nome`` do lote, permitindo
+    importar pacotes para registros já existentes.
+    """
 
     logging.info("🚀 Iniciando importação de arquivos...")
     pacotes = None
@@ -293,7 +297,11 @@ async def importar_xml(
     if pacotes is None:
         return {"erro": "Nenhum arquivo principal (.dxt, .txt, .xml, .csv) foi enviado."}
 
-    salvar_lote_db(nome, pacotes)
+    try:
+        salvar_lote_db(lote, pacotes)
+    except ValueError:
+        return {"erro": "Lote não encontrado"}
+
     return {"pacotes": pacotes}
 
 

--- a/producao/backend/src/lotes_producao.py
+++ b/producao/backend/src/lotes_producao.py
@@ -2,6 +2,7 @@
 
 from fastapi import APIRouter, HTTPException
 import json
+from typing import Union
 
 from database import get_db_connection, PLACEHOLDER, schema
 
@@ -11,33 +12,61 @@ router = APIRouter()
 SCHEMA_PREFIX = f"{schema}." if schema else ""
 
 
-def salvar_lote_db(nome: str, pacotes: list) -> None:
-    """Cria ou atualiza um lote de produção no banco."""
+def salvar_lote_db(ident: Union[str, int], pacotes: list) -> int:
+    """Cria ou atualiza um lote de produção e retorna seu ``id``.
+
+    ``ident`` pode ser o ``id`` do lote ou o ``nome``. Quando um ``id`` é
+    informado, o lote correspondente é atualizado; caso contrário, o lote é
+    criado/atualizado pelo nome.
+    """
 
     pacotes_json = json.dumps(pacotes)
     with get_db_connection() as conn:
-        conn.exec_driver_sql(
-            f"""
-            INSERT INTO {SCHEMA_PREFIX}lotes_producao (nome, pacotes_json)
-            VALUES ({PLACEHOLDER}, {PLACEHOLDER})
-            ON CONFLICT (nome)
-            DO UPDATE SET pacotes_json = {PLACEHOLDER}, atualizado_em = NOW()
-            """,
-            (nome, pacotes_json, pacotes_json),
-        )
+        if isinstance(ident, int) or str(ident).isdigit():
+            result = conn.exec_driver_sql(
+                f"""
+                UPDATE {SCHEMA_PREFIX}lotes_producao
+                SET pacotes_json={PLACEHOLDER}, atualizado_em=NOW()
+                WHERE id={PLACEHOLDER}
+                RETURNING id
+                """,
+                (pacotes_json, int(ident)),
+            )
+            lote_id = result.scalar_one_or_none()
+            if lote_id is None:
+                raise ValueError("Lote não encontrado")
+        else:
+            result = conn.exec_driver_sql(
+                f"""
+                INSERT INTO {SCHEMA_PREFIX}lotes_producao (nome, pacotes_json)
+                VALUES ({PLACEHOLDER}, {PLACEHOLDER})
+                ON CONFLICT (nome)
+                DO UPDATE SET pacotes_json = EXCLUDED.pacotes_json,
+                              atualizado_em = NOW()
+                RETURNING id
+                """,
+                (ident, pacotes_json),
+            )
+            lote_id = result.scalar_one()
+        conn.commit()
+    return lote_id
 
 
 @router.post("/lotes-producao")
 async def salvar_lote_producao(lote: dict):
     """Cria ou atualiza um lote com seus pacotes."""
 
-    nome = lote.get("nome")
+    ident = lote.get("id") or lote.get("nome")
     pacotes = lote.get("pacotes", [])
-    if not nome:
-        raise HTTPException(status_code=400, detail="Nome do lote é obrigatório")
+    if ident is None:
+        raise HTTPException(status_code=400, detail="ID ou nome do lote é obrigatório")
 
-    salvar_lote_db(nome, pacotes)
-    return {"status": "ok"}
+    try:
+        lote_id = salvar_lote_db(ident, pacotes)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Lote não encontrado")
+
+    return {"id": lote_id}
 
 
 @router.get("/lotes-producao")
@@ -46,36 +75,43 @@ async def listar_lotes_producao():
 
     with get_db_connection() as conn:
         rows = conn.exec_driver_sql(
-            f"SELECT nome, atualizado_em FROM {SCHEMA_PREFIX}lotes_producao ORDER BY atualizado_em DESC"
+            f"SELECT id, nome, atualizado_em FROM {SCHEMA_PREFIX}lotes_producao ORDER BY atualizado_em DESC"
         ).mappings().all()
     return [dict(row) for row in rows]
 
 
-@router.get("/lotes-producao/{nome}")
-async def obter_lote_producao(nome: str):
-    """Obtém os dados de um lote pelo nome."""
+@router.get("/lotes-producao/{ident}")
+async def obter_lote_producao(ident: str):
+    """Obtém os dados de um lote pelo ``id`` ou pelo ``nome``."""
+
+    campo = "id" if ident.isdigit() else "nome"
+    valor = int(ident) if ident.isdigit() else ident
 
     with get_db_connection() as conn:
         row = conn.exec_driver_sql(
-            f"SELECT pacotes_json FROM {SCHEMA_PREFIX}lotes_producao WHERE nome={PLACEHOLDER}",
-            (nome,),
+            f"SELECT id, nome, pacotes_json FROM {SCHEMA_PREFIX}lotes_producao WHERE {campo}={PLACEHOLDER}",
+            (valor,),
         ).mappings().first()
 
     if not row:
         raise HTTPException(status_code=404, detail="Lote não encontrado")
 
     pacotes = json.loads(row["pacotes_json"] or "[]")
-    return {"nome": nome, "pacotes": pacotes}
+    return {"id": row["id"], "nome": row["nome"], "pacotes": pacotes}
 
 
-@router.delete("/lotes-producao/{nome}")
-async def excluir_lote_producao(nome: str):
-    """Remove um lote pelo nome."""
+@router.delete("/lotes-producao/{ident}")
+async def excluir_lote_producao(ident: str):
+    """Remove um lote pelo ``id`` ou ``nome``."""
+
+    campo = "id" if ident.isdigit() else "nome"
+    valor = int(ident) if ident.isdigit() else ident
 
     with get_db_connection() as conn:
         conn.exec_driver_sql(
-            f"DELETE FROM {SCHEMA_PREFIX}lotes_producao WHERE nome={PLACEHOLDER}",
-            (nome,),
+            f"DELETE FROM {SCHEMA_PREFIX}lotes_producao WHERE {campo}={PLACEHOLDER}",
+            (valor,),
         )
+        conn.commit()
     return {"status": "deleted"}
 


### PR DESCRIPTION
## Summary
- allow saving production lots by either ID or name
- accept lot ID in XML import to attach packages to existing lots

## Testing
- `pytest` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_6893609a73d4832d89c204275f24adad