### PR TITLE
Persist production lot as zip with object key

### DIFF
--- a/producao/backend/src/api.py
+++ b/producao/backend/src/api.py
@@ -294,13 +294,13 @@ async def importar_xml(
                 else parse_xml_producao(root, caminho_xml)
             )
 
-    if pacotes is None:
-        return {"erro": "Nenhum arquivo principal (.dxt, .txt, .xml, .csv) foi enviado."}
+        if pacotes is None:
+            return {"erro": "Nenhum arquivo principal (.dxt, .txt, .xml, .csv) foi enviado."}
 
-    try:
-        salvar_lote_db(lote, pacotes)
-    except ValueError:
-        return {"erro": "Lote não encontrado"}
+        try:
+            salvar_lote_db(lote, pacotes, tmpdirname)
+        except ValueError:
+            return {"erro": "Lote não encontrado"}
 
     return {"pacotes": pacotes}
 

--- a/producao/backend/src/lotes_producao.py
+++ b/producao/backend/src/lotes_producao.py
@@ -2,61 +2,108 @@
 
 from fastapi import APIRouter, HTTPException
 import json
+import os
+import shutil
+import tempfile
+from pathlib import Path
 from typing import Union
+import xml.etree.ElementTree as ET
 
 from database import get_db_connection, PLACEHOLDER, schema
-from storage import upload_bytes
+from storage import (
+    upload_file,
+    download_file,
+    object_exists,
+    PREFIX as OBJECT_PREFIX,
+)
+from operacoes import parse_dxt_producao
+from nesting import _encontrar_dxt
 
 
 router = APIRouter()
 
 SCHEMA_PREFIX = f"{schema}." if schema else ""
+BASE_DIR = Path(__file__).resolve().parent.parent
+SAIDA_DIR = BASE_DIR / "saida"
 
 
-def salvar_lote_db(ident: Union[str, int], pacotes: list) -> int:
+def ensure_lote_local(key: str) -> Path:
+    """Garante que o lote identificado por ``key`` esteja extraído localmente."""
+
+    key_no_prefix = key[len(OBJECT_PREFIX) :] if key.startswith(OBJECT_PREFIX) else key
+    if not key_no_prefix.startswith("lotes/"):
+        raise ValueError("Chave de lote invalida")
+
+    pasta = SAIDA_DIR / Path(key_no_prefix).stem
+    if pasta.is_dir():
+        return pasta
+
+    status = object_exists(key)
+    if status is False:
+        raise FileNotFoundError(f"Objeto {key} nao encontrado")
+    if status is None:
+        raise FileNotFoundError(f"Objeto {key} nao encontrado")
+
+    tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".zip")
+    tmp.close()
+    try:
+        download_file(key, tmp.name)
+        shutil.unpack_archive(tmp.name, SAIDA_DIR)
+    finally:
+        os.remove(tmp.name)
+
+    return pasta
+
+
+def salvar_lote_db(ident: Union[str, int], pacotes: list, pasta_arquivos: str | None = None) -> int:
     """Cria ou atualiza um lote de produção e retorna seu ``id``.
 
-    ``ident`` pode ser o ``id`` do lote ou o ``nome``. Quando um ``id`` é
-    informado, o lote correspondente é atualizado; caso contrário, o lote é
-    criado/atualizado pelo nome.
+    Salva os pacotes em ``pacotes.json`` dentro da pasta do lote, compacta a
+    pasta completa e armazena apenas o ``obj_key`` no banco ``lotes``.
     """
 
+    nome = str(ident)
     pacotes_json = json.dumps(pacotes)
-    with get_db_connection() as conn:
-        if isinstance(ident, int) or str(ident).isdigit():
-            result = conn.exec_driver_sql(
-                f"""
-                UPDATE {SCHEMA_PREFIX}lotes_producao
-                SET pacotes_json={PLACEHOLDER}, atualizado_em=NOW()
-                WHERE id={PLACEHOLDER}
-                RETURNING id
-                """,
-                (pacotes_json, int(ident)),
-            )
-            lote_id = result.scalar_one_or_none()
-            if lote_id is None:
-                raise ValueError("Lote não encontrado")
-        else:
-            result = conn.exec_driver_sql(
-                f"""
-                INSERT INTO {SCHEMA_PREFIX}lotes_producao (nome, pacotes_json)
-                VALUES ({PLACEHOLDER}, {PLACEHOLDER})
-                ON CONFLICT (nome)
-                DO UPDATE SET pacotes_json = EXCLUDED.pacotes_json,
-                              atualizado_em = NOW()
-                RETURNING id
-                """,
-                (ident, pacotes_json),
-            )
-            lote_id = result.scalar_one()
-        conn.commit()
+    obj_key = f"lotes/Lote_{nome}.zip"
 
-    # Tenta persistir uma cópia dos pacotes no bucket S3 para redundância.
+    if pasta_arquivos:
+        pasta_tmp = Path(pasta_arquivos)
+        pasta_lote = pasta_tmp / f"Lote_{nome}"
+        os.makedirs(pasta_lote, exist_ok=True)
+        for child in list(pasta_tmp.iterdir()):
+            if child == pasta_lote:
+                continue
+            shutil.move(str(child), pasta_lote / child.name)
+    else:
+        try:
+            pasta_lote = ensure_lote_local(obj_key)
+        except Exception:
+            pasta_lote = SAIDA_DIR / f"Lote_{nome}"
+            os.makedirs(pasta_lote, exist_ok=True)
+
+    (pasta_lote / "pacotes.json").write_text(pacotes_json, encoding="utf-8")
+
+    zip_path = shutil.make_archive(
+        str(pasta_lote), "zip", root_dir=pasta_lote.parent, base_dir=pasta_lote.name
+    )
     try:
-        upload_bytes(pacotes_json.encode("utf-8"), f"lotes_producao/{lote_id}.json")
-    except Exception:
-        # Falhas de upload não devem impedir o fluxo principal.
-        pass
+        upload_file(zip_path, obj_key)
+    finally:
+        os.remove(zip_path)
+
+    with get_db_connection() as conn:
+        result = conn.exec_driver_sql(
+            f"""
+            INSERT INTO {SCHEMA_PREFIX}lotes (obj_key, criado_em)
+            VALUES ({PLACEHOLDER}, NOW())
+            ON CONFLICT (obj_key)
+            DO UPDATE SET criado_em = EXCLUDED.criado_em
+            RETURNING id
+            """,
+            (obj_key,),
+        )
+        lote_id = result.scalar_one()
+        conn.commit()
 
     return lote_id
 
@@ -85,42 +132,59 @@ async def listar_lotes_producao():
 
     with get_db_connection() as conn:
         rows = conn.exec_driver_sql(
-            f"SELECT id, nome, atualizado_em FROM {SCHEMA_PREFIX}lotes_producao ORDER BY atualizado_em DESC"
+            f"SELECT id, obj_key, criado_em FROM {SCHEMA_PREFIX}lotes ORDER BY criado_em DESC"
         ).mappings().all()
-    return [dict(row) for row in rows]
+
+    resultado = []
+    for row in rows:
+        obj_key = row.get("obj_key") or ""
+        nome = Path(obj_key).stem.replace("Lote_", "") if obj_key else ""
+        resultado.append({"id": row["id"], "nome": nome, "obj_key": obj_key})
+    return resultado
 
 
 @router.get("/lotes-producao/{ident}")
 async def obter_lote_producao(ident: str):
-    """Obtém os dados de um lote pelo ``id`` ou pelo ``nome``."""
+    """Obtém os dados de um lote pelo ``nome``."""
 
-    campo = "id" if ident.isdigit() else "nome"
-    valor = int(ident) if ident.isdigit() else ident
+    nome = ident
+    obj_key = f"lotes/Lote_{nome}.zip"
 
     with get_db_connection() as conn:
         row = conn.exec_driver_sql(
-            f"SELECT id, nome, pacotes_json FROM {SCHEMA_PREFIX}lotes_producao WHERE {campo}={PLACEHOLDER}",
-            (valor,),
+            f"SELECT id FROM {SCHEMA_PREFIX}lotes WHERE obj_key={PLACEHOLDER}",
+            (obj_key,),
         ).mappings().first()
 
     if not row:
         raise HTTPException(status_code=404, detail="Lote não encontrado")
 
-    pacotes = json.loads(row["pacotes_json"] or "[]")
-    return {"id": row["id"], "nome": row["nome"], "pacotes": pacotes}
+    pacotes: list = []
+    try:
+        pasta = ensure_lote_local(obj_key)
+        pacotes_path = pasta / "pacotes.json"
+        if pacotes_path.exists():
+            pacotes = json.loads(pacotes_path.read_text(encoding="utf-8"))
+        else:
+            dxt = _encontrar_dxt(pasta)
+            if dxt and dxt.exists():
+                root = ET.fromstring(dxt.read_text(encoding="utf-8", errors="ignore"))
+                pacotes = parse_dxt_producao(root, dxt)
+    except Exception:
+        pacotes = []
+
+    return {"id": row["id"], "nome": nome, "pacotes": pacotes}
 
 
 @router.delete("/lotes-producao/{ident}")
 async def excluir_lote_producao(ident: str):
-    """Remove um lote pelo ``id`` ou ``nome``."""
+    """Remove um lote pelo ``nome``."""
 
-    campo = "id" if ident.isdigit() else "nome"
-    valor = int(ident) if ident.isdigit() else ident
-
+    obj_key = f"lotes/Lote_{ident}.zip"
     with get_db_connection() as conn:
         conn.exec_driver_sql(
-            f"DELETE FROM {SCHEMA_PREFIX}lotes_producao WHERE {campo}={PLACEHOLDER}",
-            (valor,),
+            f"DELETE FROM {SCHEMA_PREFIX}lotes WHERE obj_key={PLACEHOLDER}",
+            (obj_key,),
         )
         conn.commit()
     return {"status": "deleted"}

--- a/producao/backend/src/models.py
+++ b/producao/backend/src/models.py
@@ -151,13 +151,3 @@ class ChapaEstoqueMov(Base):
     destino = Column(String)
     criado_em = Column(String)
 
-class LoteProducao(Base):
-    __tablename__ = "lotes_producao"
-
-    id = Column(Integer, primary_key=True)
-    nome = Column(Text, unique=True, nullable=False)
-    pacotes_json = Column(Text)
-    usuario_id = Column(Integer, nullable=True)
-    criado_em = Column(TIMESTAMP, server_default=func.now())
-    atualizado_em = Column(TIMESTAMP, server_default=func.now(), onupdate=func.now())
-


### PR DESCRIPTION
### Summary
- store production lot data as zipped archive in object storage and record obj_key in base `lotes` table
- load pacotes from stored archive when retrieving lots
- update import flow and remove dedicated `lotes_producao` table usage

### Testing
- `pytest` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_689388d41df8832d8eea986af8ce083f