### PR TITLE
Restrict admin routes to administrators and expose trainings to all users

### DIFF
--- a/frontend-erp/src/App.jsx
+++ b/frontend-erp/src/App.jsx
@@ -25,6 +25,7 @@ import { UserContext } from "./UserContext";
 // Componente de Layout: A "moldura" do ERP para um usuário logado
 function Layout({ usuario, onLogout }) {
   const possuiPermissao = (modulo) => usuario?.permissoes?.includes(modulo);
+  const isAdmin = usuario?.cargo === 'admin';
 
   const matchCadastros = useMatch("/cadastros/*");
   const matchMarketing = useMatch("/marketing-ia/*");
@@ -41,7 +42,7 @@ function Layout({ usuario, onLogout }) {
         <h1 className="text-2xl font-bold">Radha ERP</h1>
         <p className="text-sm mb-4">Usuário: {usuario?.nome}</p>
         <nav className="flex flex-col space-y-2 flex-grow">
-          {possuiPermissao("cadastros") && (
+          {isAdmin && (
             <Link
               to="/cadastros"
               className={`px-2 py-1 rounded ${matchCadastros ? "bg-blue-700" : "hover:bg-blue-700"}`}
@@ -97,14 +98,12 @@ function Layout({ usuario, onLogout }) {
               Formulários
             </Link>
           )}
-          {possuiPermissao("universidade-radha") && (
-            <Link
-              to="/universidade-radha"
-              className={`px-2 py-1 rounded ${matchUniversidade ? "bg-blue-700" : "hover:bg-blue-700"}`}
-            >
-              Universidade Radha
-            </Link>
-          )}
+          <Link
+            to="/universidade-radha"
+            className={`px-2 py-1 rounded ${matchUniversidade ? "bg-blue-700" : "hover:bg-blue-700"}`}
+          >
+            Treinamentos
+          </Link>
         </nav>
         <button
           onClick={onLogout}
@@ -191,6 +190,13 @@ function App() {
     navigate("/");
   };
 
+  const AdminRoute = ({ children }) => {
+    if (usuarioLogado?.cargo !== 'admin') {
+      return <Navigate to="/" replace />;
+    }
+    return children;
+  };
+
   useEffect(() => {
     const handler = (e) => {
       const msg = e.detail;
@@ -222,7 +228,7 @@ function App() {
           }
         >
           <Route index element={<p className="text-center text-lg mt-10">Bem-vindo ao ERP Radha. Selecione um módulo no menu.</p>} />
-          <Route path="cadastros/*" element={<Cadastros />} />
+          <Route path="cadastros/*" element={<AdminRoute><Cadastros /></AdminRoute>} />
           <Route path="marketing-ia/*" element={<MarketingDigitalIA />} />
           <Route path="producao/*" element={<Producao />} />
           <Route path="planos-producao/*" element={<PlanosProducao />} />

--- a/frontend-erp/src/modules/UniversidadeRadha/index.jsx
+++ b/frontend-erp/src/modules/UniversidadeRadha/index.jsx
@@ -2,12 +2,12 @@
 import React from 'react';
 import { Routes, Route, Outlet } from 'react-router-dom';
 
-// Layout simples para o módulo Universidade Radha
+// Layout simples para o módulo de Treinamentos
 function UniversidadeRadhaLayout() {
   return (
     <div className="p-4 bg-white rounded shadow-md">
       <h2 className="text-xl font-bold mb-4 text-blue-700">
-        Módulo: Universidade Radha
+        Módulo: Treinamentos
       </h2>
       <Outlet />
     </div>
@@ -15,7 +15,7 @@ function UniversidadeRadhaLayout() {
 }
 
 function UniversidadeRadhaHome() {
-  return <div>Bem-vindo à Universidade Radha!</div>;
+  return <div>Bem-vindo aos Treinamentos!</div>;
 }
 
 // Componente principal do módulo


### PR DESCRIPTION
## Summary
- limit Cadastros module to users with cargo `admin`
- show Treinamentos to every authenticated user

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: error in src/modules/Comercial/pages/Negociacao.jsx)*
- `npx eslint src/App.jsx`
- `npx eslint src/modules/UniversidadeRadha/index.jsx`


------
https://chatgpt.com/codex/tasks/task_e_6893c6bb97f0832d8820bc0b355ab118