### PR TITLE
feat: add document search indexing

### DIFF
--- a/marketing-digital-ia/backend/requirements.txt
+++ b/marketing-digital-ia/backend/requirements.txt
@@ -14,3 +14,4 @@ sqlalchemy
 psycopg2-binary
 numpy
 boto3
+Whoosh

--- a/marketing-digital-ia/backend/routes/conhecimento.py
+++ b/marketing-digital-ia/backend/routes/conhecimento.py
@@ -1,10 +1,33 @@
 # routes/conhecimento.py
-from fastapi import APIRouter, Request, Depends
+from fastapi import APIRouter, Request, Depends, UploadFile, File, Form
 from services.embedding_service import buscar_contexto
+from services.search_service import indexar_documento, buscar_documentos
 from openai import OpenAI
 from security import verificar_autenticacao
 
 router = APIRouter(tags=["Conhecimento"])
+
+
+@router.post("/conhecimento/importar")
+async def importar_conhecimento(
+    titulo: str = Form(...),
+    arquivo: UploadFile = File(...),
+    usuario=Depends(
+        verificar_autenticacao(permissoes=["marketing-ia/gerir-conhecimento"])
+    ),
+):
+    conteudo = (await arquivo.read()).decode("utf-8", errors="ignore")
+    indexar_documento(titulo, conteudo)
+    return {"status": "ok"}
+
+
+@router.get("/conhecimento/buscar")
+async def buscar_conhecimento(
+    q: str,
+    usuario=Depends(verificar_autenticacao(permissoes=["marketing-ia/chat"])),
+):
+    resultados = buscar_documentos(q)
+    return {"resultados": resultados}
 
 @router.post("/perguntar-sara")
 async def perguntar_sara(

--- a/marketing-digital-ia/backend/services/search_service.py
+++ b/marketing-digital-ia/backend/services/search_service.py
@@ -1,0 +1,30 @@
+from whoosh import index
+from whoosh.fields import Schema, TEXT
+from whoosh.qparser import MultifieldParser
+import os
+
+INDEX_DIR = "whoosh_index"
+
+
+def _get_or_create_index():
+    if not os.path.exists(INDEX_DIR):
+        os.makedirs(INDEX_DIR)
+        schema = Schema(title=TEXT(stored=True), content=TEXT(stored=True))
+        return index.create_in(INDEX_DIR, schema)
+    return index.open_dir(INDEX_DIR)
+
+
+def indexar_documento(titulo: str, conteudo: str) -> None:
+    ix = _get_or_create_index()
+    writer = ix.writer()
+    writer.add_document(title=titulo, content=conteudo)
+    writer.commit()
+
+
+def buscar_documentos(termo: str, limite: int = 10):
+    ix = _get_or_create_index()
+    with ix.searcher() as searcher:
+        parser = MultifieldParser(["title", "content"], schema=ix.schema)
+        query = parser.parse(termo)
+        resultados = searcher.search(query, limit=limite)
+        return [{"titulo": r["title"], "conteudo": r["content"], "score": r.score} for r in resultados]


### PR DESCRIPTION
## Summary
- add endpoints to import and search knowledge base documents
- implement Whoosh search service to index title and content
- include Whoosh dependency for knowledge module

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'gabster_api')*

------
https://chatgpt.com/codex/tasks/task_e_6893c6c1f7d0832d8fd1dc16b1cf7cdd