### PR TITLE
fix: close navigation links in Universidade Radha

### DIFF
--- a/frontend-erp/src/modules/UniversidadeRadha/index.jsx
+++ b/frontend-erp/src/modules/UniversidadeRadha/index.jsx
@@ -21,13 +21,13 @@ function UniversidadeRadhaLayout() {
 
         <Link to="treinamentos" className="text-blue-600 hover:underline">
           Treinamentos
+        </Link>
 
         <Link
           to="gerenciar-conteudos"
           className="text-blue-600 hover:underline"
         >
           Gerenciar Conteúdos
-
         </Link>
       </nav>
       <Outlet />


### PR DESCRIPTION
## Summary
- fix mismatched closing tags in UniversidadeRadha layout navigation to allow build

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6893c09858a4832dab10963483c9c28d