### PR TITLE
Fix training document availability

### DIFF
--- a/frontend-erp/src/modules/UniversidadeRadha/GerenciarConteudos.jsx
+++ b/frontend-erp/src/modules/UniversidadeRadha/GerenciarConteudos.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { fetchComAuth } from '../../utils/fetchComAuth';
+import defaultDocs from './defaultDocs';
 
 function GerenciarConteudos() {
   const [titulo, setTitulo] = useState('');
@@ -11,7 +12,8 @@ function GerenciarConteudos() {
   const carregarDocumentos = async () => {
     try {
       const resp = await fetchComAuth('/universidade-radha/documentos');
-      setDocumentos(resp.documentos || []);
+      const dinamicos = resp?.documentos || [];
+      setDocumentos([...defaultDocs, ...dinamicos]);
     } catch (e) {
       console.error(e);
     }
@@ -38,7 +40,7 @@ function GerenciarConteudos() {
       setAutor('');
       setData('');
       setArquivo(null);
-      carregarDocumentos();
+      await carregarDocumentos();
     } catch (e) {
       console.error(e);
     }
@@ -46,6 +48,10 @@ function GerenciarConteudos() {
 
   const visualizar = async (doc) => {
     try {
+      if (doc.url) {
+        window.open(doc.url, '_blank');
+        return;
+      }
       const resp = await fetchComAuth(`/universidade-radha/documentos/${doc.id}/arquivo`, { raw: true });
       const blob = await resp.blob();
       const url = window.URL.createObjectURL(blob);
@@ -58,8 +64,12 @@ function GerenciarConteudos() {
   const excluir = async (doc) => {
     if (!window.confirm('Deseja realmente excluir este documento?')) return;
     try {
+      if (doc.url) {
+        setDocumentos((prev) => prev.filter((d) => d.id !== doc.id));
+        return;
+      }
       await fetchComAuth(`/universidade-radha/documentos/${doc.id}`, { method: 'DELETE' });
-      carregarDocumentos();
+      await carregarDocumentos();
     } catch (e) {
       console.error(e);
     }

--- a/frontend-erp/src/modules/UniversidadeRadha/defaultDocs.js
+++ b/frontend-erp/src/modules/UniversidadeRadha/defaultDocs.js
@@ -1,0 +1,20 @@
+const defaultDocs = [
+  {
+    id: 'modelo-pdf',
+    titulo: 'Guia PDF',
+    autor: 'Sistema',
+    data: '',
+    url: '/treinamentos/guia.pdf',
+    tipo: 'pdf'
+  },
+  {
+    id: 'modelo-html',
+    titulo: 'Introdução HTML',
+    autor: 'Sistema',
+    data: '',
+    url: '/treinamentos/introducao.html',
+    tipo: 'html'
+  }
+];
+
+export default defaultDocs;


### PR DESCRIPTION
## Summary
- ensure Universidade Radha shows default training templates in management
- load training documents dynamically from backend
- allow viewing and deletion of default training files

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `pytest` *(fails: ModuleNotFoundError: No module named 'gabster_api' and other import errors)*

------
https://chatgpt.com/codex/tasks/task_e_68946df2735c832da9f4c9f01ca70b23