### PR TITLE
Fix S3 object existence check for production lots

### DIFF
--- a/producao/backend/src/storage.py
+++ b/producao/backend/src/storage.py
@@ -131,17 +131,7 @@ def object_exists(object_name: str) -> bool | None:
             full_key,
             ", ".join(missing_vars) if missing_vars else "nenhuma",
         )
-    return None
-
-def get_object_size(object_name: str) -> int | None:
-    """Retorna o tamanho (em bytes) do objeto, ou None se não disponível."""
-    if client:
-        try:
-            resp = client.head_object(Bucket=BUCKET, Key=_full_key(object_name))
-            return resp.get("ContentLength")
-        except Exception:
-            return None
-    return None
+        return None
 
     try:
         client.head_object(Bucket=BUCKET, Key=full_key)
@@ -173,6 +163,17 @@ def get_object_size(object_name: str) -> int | None:
             e,
         )
         return None
+
+
+def get_object_size(object_name: str) -> int | None:
+    """Retorna o tamanho (em bytes) do objeto, ou None se não disponível."""
+    if client:
+        try:
+            resp = client.head_object(Bucket=BUCKET, Key=_full_key(object_name))
+            return resp.get("ContentLength")
+        except Exception:
+            return None
+    return None
 
 
 


### PR DESCRIPTION
## Summary
- ensure `object_exists` checks S3 and returns the correct status

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'gabster_api', ImportError: cannot import name 'DEFAULT_ADMIN_PERMISSIONS' from 'database', Failed: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68961bf3a354832d9bd5eb4d539e00b3