### PR TITLE
fix: persist uploaded training docs

### DIFF
--- a/frontend-erp/src/modules/UniversidadeRadha/GerenciarConteudos.jsx
+++ b/frontend-erp/src/modules/UniversidadeRadha/GerenciarConteudos.jsx
@@ -32,20 +32,19 @@ function GerenciarConteudos() {
     fd.append('data', data);
     fd.append('arquivo', arquivo);
     try {
-      const resp = await fetchComAuth('/universidade-radha/documentos', {
+      await fetchComAuth('/universidade-radha/documentos', {
         method: 'POST',
         body: fd,
       });
-      // Atualiza a lista imediatamente com o documento recém-enviado
-      setDocumentos((prev) => [
-        ...prev,
-        { id: resp.id, titulo, autor, data },
-      ]);
+
       setTitulo('');
       setAutor('');
       setData('');
       setArquivo(null);
       e.target.reset && e.target.reset();
+
+      await carregarDocumentos();
+      window.dispatchEvent(new Event('documentosAtualizados'));
     } catch (e) {
       console.error(e);
     }

--- a/frontend-erp/src/modules/UniversidadeRadha/Treinamentos.jsx
+++ b/frontend-erp/src/modules/UniversidadeRadha/Treinamentos.jsx
@@ -69,6 +69,9 @@ function Treinamentos() {
       setDocs(processed);
     };
     loadDocs();
+    const handler = () => loadDocs();
+    window.addEventListener('documentosAtualizados', handler);
+    return () => window.removeEventListener('documentosAtualizados', handler);
   }, []);
 
   const filtered = docs.filter((doc) => {


### PR DESCRIPTION
## Summary
- ensure Gerenciar Conteúdos reloads documents after upload and notifies listeners
- allow Treinamentos to refresh when documents are updated

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68961c5fec88832d9af70120407acc31